### PR TITLE
chore: rename sdk-js to client

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -87,10 +87,10 @@ body:
     attributes:
       label: Confirmation Checklist
       options:
-        - label: I have checked the existing [issues](https://github.com/strapi/sdk-js/issues)
+        - label: I have checked the existing [issues](https://github.com/strapi/client/issues)
           required: true
 
-        - label: I agree to follow this project's [Code of Conduct](https://github.com/strapi/sdk-js/blob/main/CODE_OF_CONDUCT.md)
+        - label: I agree to follow this project's [Code of Conduct](https://github.com/strapi/client/blob/main/CODE_OF_CONDUCT.md)
           required: true
 
         - label: I would like to work on this issue

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yml
@@ -6,8 +6,8 @@ body:
   - type: textarea
     attributes:
       label: Bug Description
-      description: Provide a clear and concise description of the issue or unexpected behavior related to the Strapi SDK client.
-      placeholder: Using the SDK client to fetch data from the "articles" collection does not return the expected results.
+      description: Provide a clear and concise description of the issue or unexpected behavior related to the Strapi Client.
+      placeholder: Using the Strapi client to fetch data from the "articles" collection does not return the expected results.
     validations:
       required: true
 
@@ -18,8 +18,8 @@ body:
       placeholder: |
         Example:
           1. Initialize a new Strapi project with an "article" collection type defined as "...".
-          2. Configure the SDK client with your Strapi API URL and authentication token.
-          3. Perform a query to fetch entries from a collection: `sdk.collection('articles').find()`.
+          2. Configure the Strapi client with your Strapi API URL and authentication token.
+          3. Perform a query to fetch entries from a collection: `client.collection('articles').find()`.
           4. Observe the unexpected behavior or error in the response/output.
     validations:
       required: true
@@ -35,7 +35,7 @@ body:
     id: version
     attributes:
       label: Version
-      description: The version of the SDK that was used.
+      description: The version of the Strapi Client that was used.
       placeholder: 1.0.0
     validations:
       required: true
@@ -73,7 +73,7 @@ body:
     id: logs
     attributes:
       label: Logs
-      description: If available, please provide the logs generated while using the SDK.
+      description: If available, please provide the logs generated while using the client.
       render: shell
 
   - type: textarea

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 1. [Getting Started](#-getting-started)
    - [Prerequisites](#pre-requisites)
    - [Installation](#installation)
-2. [Creating and Configuring an SDK Instance](#-creating-and-configuring-the-sdk-instance)
+2. [Creating and Configuring a Client Instance](#-creating-and-configuring-the-sdk-instance)
    - [Basic Configuration](#basic-configuration)
    - [Authentication](#authentication)
      - [API Token Authentication](#api-token-authentication)
@@ -57,7 +57,7 @@ Before you begin, ensure you have the following:
 
 ### Installation
 
-Install the SDK as a dependency in your project:
+Install the client as a dependency in your project:
 
 **NPM**
 
@@ -77,16 +77,16 @@ yarn add @strapi/client
 pnpm add @strapi/client
 ```
 
-## ⚙️ Creating and configuring the SDK Instance
+## ⚙️ Creating and configuring the client Instance
 
 ### Basic configuration
 
-To interact with your Strapi backend, initialize the SDK with your Strapi API base URL:
+To interact with your Strapi backend, initialize the client with your Strapi API base URL:
 
 ```typescript
 import { strapi } from '@strapi/client';
 
-const sdk = strapi({ baseURL: 'http://localhost:1337/api' });
+const client = strapi({ baseURL: 'http://localhost:1337/api' });
 ```
 
 Alternatively, use a `<script>` tag in a browser environment:
@@ -95,7 +95,7 @@ Alternatively, use a `<script>` tag in a browser environment:
 <script src="https://cdn.jsdelivr.net/npm/@strapi/client"></script>
 
 <script>
-  const sdk = strapi.strapi({ baseURL: 'http://localhost:1337/api' });
+  const client = strapi.strapi({ baseURL: 'http://localhost:1337/api' });
 </script>
 ```
 
@@ -105,10 +105,10 @@ The SDK supports multiple authentication strategies for accessing authenticated 
 
 #### API-Token authentication
 
-If your Strapi instance uses API tokens, configure the SDK like this:
+If your Strapi instance uses API tokens, configure the client like this:
 
 ```typescript
-const sdk = strapi({
+const client = strapi({
   // Endpoint configuration
   baseURL: 'http://localhost:1337/api',
   // Auth configuration
@@ -118,7 +118,7 @@ const sdk = strapi({
 
 ## 📚 API Reference
 
-The Strapi SDK instance provides key properties and utility methods for content and API interaction:
+The Strapi Client SDK instance provides key properties and utility methods for content and API interaction:
 
 - **`baseURL`**: base URL of your Strapi backend.
 - **`fetch`**: perform generic requests to the Strapi Content API using fetch-like syntax.
@@ -145,7 +145,7 @@ which can have multiple entries.
 #### Examples:
 
 ```typescript
-const articles = sdk.collection('articles');
+const articles = client.collection('articles');
 
 // Fetch all english articles sorted by title
 const allArticles = await articles.find({
@@ -181,7 +181,7 @@ The `.single()` method provides a manager for working with single-type resources
 #### Examples:
 
 ```typescript
-const homepage = sdk.single('homepage');
+const homepage = client.single('homepage');
 
 // Fetch the default version of the homepage
 const defaultHomepage = await homepage.find();
@@ -254,7 +254,7 @@ Below is a list of available namespaces to use:
 
 ## 🚀 Demo Projects
 
-This repository includes demo projects located in the `/demo` directory to help you get started with using the Strapi SDK. The actual Strapi application is located in the `.strapi-app` directory.
+This repository includes demo projects located in the `/demo` directory to help you get started with using the client. The actual Strapi application is located in the `.strapi-app` directory.
 
 ### Demo Structure
 
@@ -264,7 +264,7 @@ This repository includes demo projects located in the `/demo` directory to help 
 
 ### Using Demo Scripts
 
-The `package.json` includes several scripts to help you manage and run the demo projects. These scripts are designed to streamline the process of setting up and running the demo projects, making it easier for developers to test and interact with the SDK.
+The `package.json` includes several scripts to help you manage and run the demo projects. These scripts are designed to streamline the process of setting up and running the demo projects, making it easier for developers to test and interact with the client.
 
 The most important basic commands to get started are:
 
@@ -323,4 +323,4 @@ We plan to expand the demo projects to include:
 - A basic HTML project.
 - A Next.js project.
 
-These additions will provide more examples of how to integrate the Strapi SDK into different types of applications.
+These additions will provide more examples of how to integrate the client into different types of applications.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Alternatively, use a `<script>` tag in a browser environment:
 
 ### Authentication
 
-The SDK supports multiple authentication strategies for accessing authenticated content in your Strapi backend.
+The client library supports multiple authentication strategies for accessing authenticated content in your Strapi backend.
 
 #### API-Token authentication
 
@@ -118,7 +118,7 @@ const client = strapi({
 
 ## 📚 API Reference
 
-The Strapi Client SDK instance provides key properties and utility methods for content and API interaction:
+The Strapi client library instance provides key properties and utility methods for content and API interaction:
 
 - **`baseURL`**: base URL of your Strapi backend.
 - **`fetch`**: perform generic requests to the Strapi Content API using fetch-like syntax.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 1. [Getting Started](#-getting-started)
    - [Prerequisites](#pre-requisites)
    - [Installation](#installation)
-2. [Creating and Configuring a Client Instance](#-creating-and-configuring-the-sdk-instance)
+2. [Creating and Configuring a Strapi Client Instance](#-creating-and-configuring-the-sdk-instance)
    - [Basic Configuration](#basic-configuration)
    - [Authentication](#authentication)
      - [API Token Authentication](#api-token-authentication)

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@
 <br />
 
 <p align="center">
-  <a href="https://www.npmjs.org/package/@strapi/sdk-js">
-    <img src="https://img.shields.io/npm/v/@strapi/sdk-js/latest.svg" alt="NPM Version" />
+  <a href="https://www.npmjs.org/package/@strapi/client">
+    <img src="https://img.shields.io/npm/v/@strapi/client/latest.svg" alt="NPM Version" />
   </a>
-  <a href="https://www.npmjs.com/package/@strapi/sdk-js" target="_blank">
-   <img src="https://img.shields.io/npm/dm/@strapi/sdk-js" alt="NPM downloads" />
+  <a href="https://www.npmjs.com/package/@strapi/client" target="_blank">
+   <img src="https://img.shields.io/npm/dm/@strapi/client" alt="NPM downloads" />
   </a>
-  <a href="https://github.com/strapi/sdk-js/actions/workflows/tests.yml">
-    <img src="https://github.com/strapi/sdk-js/actions/workflows/tests.yml/badge.svg?branch=main" alt="Tests" />
+  <a href="https://github.com/strapi/client/actions/workflows/tests.yml">
+    <img src="https://github.com/strapi/client/actions/workflows/tests.yml/badge.svg?branch=main" alt="Tests" />
   </a>
   <a href="https://discord.strapi.io">
     <img src="https://img.shields.io/discord/811989166782021633?label=Discord" alt="Strapi on Discord" />
@@ -62,19 +62,19 @@ Install the SDK as a dependency in your project:
 **NPM**
 
 ```bash
-npm install @strapi/sdk-js
+npm install @strapi/client
 ```
 
 **Yarn**
 
 ```bash
-yarn add @strapi/sdk-js
+yarn add @strapi/client
 ```
 
 **pnpm**
 
 ```bash
-pnpm add @strapi/sdk-js
+pnpm add @strapi/client
 ```
 
 ## ⚙️ Creating and configuring the SDK Instance
@@ -84,7 +84,7 @@ pnpm add @strapi/sdk-js
 To interact with your Strapi backend, initialize the SDK with your Strapi API base URL:
 
 ```typescript
-import { strapi } from '@strapi/sdk-js';
+import { strapi } from '@strapi/client';
 
 const sdk = strapi({ baseURL: 'http://localhost:1337/api' });
 ```
@@ -92,7 +92,7 @@ const sdk = strapi({ baseURL: 'http://localhost:1337/api' });
 Alternatively, use a `<script>` tag in a browser environment:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@strapi/sdk-js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@strapi/client"></script>
 
 <script>
   const sdk = strapi.strapi({ baseURL: 'http://localhost:1337/api' });

--- a/demo/node-javascript/package.json
+++ b/demo/node-javascript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "demo-node-javascript",
   "version": "1.0.0",
-  "description": "A Strapi SDK demo using a Node x JavaScript application",
+  "description": "A Strapi Client demo using a Node x JavaScript application",
   "main": "index.js",
   "scripts": {
     "start": "node src/index.js",

--- a/demo/node-javascript/package.json
+++ b/demo/node-javascript/package.json
@@ -8,7 +8,7 @@
     "debug": "DEBUG=* node src/index.js"
   },
   "dependencies": {
-    "@strapi/sdk-js": "link:../..",
+    "@strapi/client": "link:../..",
     "dotenv": "16.4.7"
   },
   "keywords": [],

--- a/demo/node-javascript/pnpm-lock.yaml
+++ b/demo/node-javascript/pnpm-lock.yaml
@@ -8,7 +8,7 @@ importers:
 
   .:
     dependencies:
-      '@strapi/sdk-js':
+      '@strapi/client':
         specifier: link:../..
         version: link:../..
       dotenv:

--- a/demo/node-javascript/src/index.js
+++ b/demo/node-javascript/src/index.js
@@ -6,11 +6,11 @@ const api_token = process.env.FULL_ACCESS_TOKEN; // READ_ONLY_TOKEN is also avai
 console.log('Running with api token ' + api_token);
 
 async function main() {
-  // Create the SDK instance
-  const sdk = strapi({ baseURL: 'http://localhost:1337/api', auth: api_token });
+  // Create the Strapi client instance
+  const client = strapi({ baseURL: 'http://localhost:1337/api', auth: api_token });
 
   // Create a collection type query manager for the categories
-  const categories = sdk.collection('categories');
+  const categories = client.collection('categories');
 
   // Fetch the list of all categories
   const docs = await categories.find();

--- a/demo/node-javascript/src/index.js
+++ b/demo/node-javascript/src/index.js
@@ -1,4 +1,4 @@
-const { strapi } = require('@strapi/sdk-js');
+const { strapi } = require('@strapi/client');
 require('dotenv').config();
 
 const api_token = process.env.FULL_ACCESS_TOKEN; // READ_ONLY_TOKEN is also available

--- a/demo/node-typescript/package.json
+++ b/demo/node-typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "demo-node-typescript",
   "version": "1.0.0",
-  "description": "A Strapi SDK demo using a Node x TypeScript application",
+  "description": "A Strapi Client demo using a Node x TypeScript application",
   "main": "dist/index.js",
   "private": true,
   "type": "module",

--- a/demo/node-typescript/package.json
+++ b/demo/node-typescript/package.json
@@ -12,7 +12,7 @@
     "debug": "DEBUG=* node dist/index.js"
   },
   "dependencies": {
-    "@strapi/sdk-js": "link:../..",
+    "@strapi/client": "link:../..",
     "dotenv": "16.4.7"
   },
   "devDependencies": {

--- a/demo/node-typescript/pnpm-lock.yaml
+++ b/demo/node-typescript/pnpm-lock.yaml
@@ -8,7 +8,7 @@ importers:
 
   .:
     dependencies:
-      '@strapi/sdk-js':
+      '@strapi/client':
         specifier: link:../..
         version: link:../..
       dotenv:

--- a/demo/node-typescript/src/index.ts
+++ b/demo/node-typescript/src/index.ts
@@ -1,4 +1,4 @@
-import { strapi } from '@strapi/sdk-js';
+import { strapi } from '@strapi/client';
 import * as dotenv from 'dotenv';
 dotenv.config();
 

--- a/demo/node-typescript/src/index.ts
+++ b/demo/node-typescript/src/index.ts
@@ -6,10 +6,10 @@ const api_token = process.env.FULL_ACCESS_TOKEN; // READ_ONLY_TOKEN is also avai
 
 console.log('Running with api token ' + api_token);
 
-// Create the SDK instance
-const sdk = strapi({ baseURL: 'http://localhost:1337/api', auth: api_token });
+// Create the Strapi client instance
+const client = strapi({ baseURL: 'http://localhost:1337/api', auth: api_token });
 // Create a collection type query manager for the categories
-const categories = sdk.collection('categories');
+const categories = client.collection('categories');
 
 // Fetch the list of all categories
 const docs = await categories.find();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@strapi/client",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "description": "The official client library to easily interface with Strapi from your JavaScript/TypeScript project",
   "keywords": [
     "strapi",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@strapi/client",
   "version": "1.0.0",
-  "description": "A client SDK to easily interface with Strapi from your javascript/typescript project",
+  "description": "The official client SDK to easily interface with Strapi from your JavaScript/TypeScript project",
   "keywords": [
     "strapi",
     "sdk",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@strapi/client",
-  "version": "1.0.0",
-  "description": "The official client SDK to easily interface with Strapi from your JavaScript/TypeScript project",
+  "version": "0.0.0",
+  "description": "The official client library to easily interface with Strapi from your JavaScript/TypeScript project",
   "keywords": [
     "strapi",
     "sdk",
+    "library",
     "client",
     "js",
     "ts"

--- a/package.json
+++ b/package.json
@@ -1,15 +1,17 @@
 {
-  "name": "@strapi/sdk-js",
+  "name": "@strapi/client",
   "version": "1.0.0",
-  "description": "An SDK you can use the easily interface with Strapi from your javascript project",
+  "description": "A client SDK to easily interface with Strapi from your javascript/typescript project",
   "keywords": [
     "strapi",
     "sdk",
-    "js"
+    "client",
+    "js",
+    "ts"
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/strapi/sdk-js.git"
+    "url": "https://github.com/strapi/client.git"
   },
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -7,7 +7,7 @@ import terser from '@rollup/plugin-terser';
 const isProduction = process.env.NODE_ENV === 'production';
 
 /**
- * This configuration is designed to bundle the Strapi SDK for Node.js environments.
+ * This configuration is designed to bundle the Strapi Client for Node.js environments.
  *
  * It produces two outputs: one for the older CommonJS module system and one for the modern ES Module
  * system, ensuring compatibility with a wide range of tools and runtimes.
@@ -69,7 +69,7 @@ const node_build = {
 };
 
 /**
- * This configuration is designed to bundle the Strapi SDK for browser environments.
+ * This configuration is designed to bundle the Strapi Client for browser environments.
  *
  * It outputs using the IIFE format, which is suitable for use in web browsers.
  *

--- a/src/auth/manager.ts
+++ b/src/auth/manager.ts
@@ -162,7 +162,7 @@ export class AuthManager {
   }
 
   /**
-   * Registers the SDK default authentication providers in the factory so that they can be later selected.
+   * Registers the client default authentication providers in the factory so that they can be later selected.
    *
    * The default authentication providers are:
    * - API Token ({@link ApiTokenAuthProvider})

--- a/src/auth/providers/users-permissions.ts
+++ b/src/auth/providers/users-permissions.ts
@@ -36,7 +36,7 @@ export type UsersPermissionsAuthPayload = Pick<
 /**
  * @experimental
  * Authentication through users and permissions is experimental for the MVP of
- * the Strapi SDK.
+ * the Strapi client.
  */
 export class UsersPermissionsAuthProvider extends AbstractAuthProvider<UsersPermissionsAuthProviderOptions> {
   public static readonly identifier = USERS_PERMISSIONS_AUTH_STRATEGY_IDENTIFIER;

--- a/src/client.ts
+++ b/src/client.ts
@@ -12,7 +12,7 @@ import type { HttpClientConfig } from './http';
 const debug = createDebug('strapi:core');
 
 export interface StrapiConfig {
-  /** The base URL of the Strapi content API, required for all SDK operations. */
+  /** The base URL of the Strapi content API, required for all client library operations. */
   baseURL: string;
 
   /** Optional authentication configuration, which specifies a strategy and its details. */
@@ -20,7 +20,7 @@ export interface StrapiConfig {
 }
 
 /**
- * Describes an authentication strategy used in the SDK configuration.
+ * Describes an authentication strategy used in the client library configuration.
  *
  * @template T The type of options for the authentication strategy.
  */
@@ -81,27 +81,27 @@ export class Strapi {
 
     // The HTTP client depends on the preflightValidation for the baseURL validity.
     // It could be instantiated before but would throw an invalid URL error
-    // instead of the SDK itself throwing an initialization exception.
+    // instead of the client library itself throwing an initialization exception.
     this._httpClient = httpClientFactory
       ? httpClientFactory({ baseURL: config.baseURL })
       : new HttpClient({ baseURL: config.baseURL });
 
     this.init();
 
-    debug('finished the sdk initialization process');
+    debug('finished the client initialization process');
   }
 
   /**
-   * Performs preliminary validation of the SDK configuration.
+   * Performs preliminary validation of the client configuration.
    *
-   * This method ensures that the provided configuration for the SDK is valid by using the
-   * internal SDK validator. It is invoked during the initialization process to confirm that
+   * This method ensures that the provided configuration for the client is valid by using the
+   * internal client validator. It is invoked during the initialization process to confirm that
    * all necessary parts are correctly configured before effectively using the client.
    *
-   * @throws {StrapiInitializationError} If the configuration validation fails, indicating an issue with the SDK initialization process.
+   * @throws {StrapiInitializationError} If the configuration validation fails, indicating an issue with the client initialization process.
    *
    * @example
-   * // Creating a new instance of the SDK which triggers preflightValidation
+   * // Creating a new instance of the client which triggers preflightValidation
    * const config = {
    *   baseURL: 'https://example.com',
    *   auth: {
@@ -114,7 +114,7 @@ export class Strapi {
    * // The preflightValidation is automatically called within the constructor
    * // to ensure the provided config is valid prior to any further setup.
    *
-   * @note This method is private and only called internally during SDK initialization.
+   * @note This method is private and only called internally during client initialization.
    *
    * @internal
    */
@@ -150,7 +150,7 @@ export class Strapi {
    * and that errors are properly converted into meaningful exceptions for easier debugging.
    *
    * @note
-   * This method is private and should only be invoked internally during the SDK initialization process.
+   * This method is private and should only be invoked internally during the client initialization process.
    *
    * @internal
    */
@@ -174,7 +174,7 @@ export class Strapi {
    * - Handle authentication errors (for example, unauthorized responses) consistently.
    *
    * @note
-   * This method is private and should only be invoked internally during the SDK initialization process.
+   * This method is private and should only be invoked internally during the client initialization process.
    *
    * @internal
    */
@@ -192,7 +192,7 @@ export class Strapi {
       } catch (e) {
         throw new StrapiInitializationError(
           e,
-          `Failed to initialize the SDK auth manager: ${e instanceof StrapiError ? e.cause : e}`
+          `Failed to initialize the client auth manager: ${e instanceof StrapiError ? e.cause : e}`
         );
       }
     }
@@ -211,7 +211,7 @@ export class Strapi {
   /**
    * Retrieves the authentication configuration for the Strapi client.
    *
-   * @note This is a private property used internally within the SDK for configuring authentication in the HTTP layer.
+   * @note This is a private property used internally within the client for configuring authentication in the HTTP layer.
    *
    * @internal
    */
@@ -222,12 +222,12 @@ export class Strapi {
   /**
    * Retrieves the base URL of the Strapi Client instance.
    *
-   * This getter returns the `baseURL` property stored within the SDK's configuration object.
+   * This getter returns the `baseURL` property stored within the client's configuration object.
    *
    * The base URL is used as the starting point for all HTTP requests initiated through the client.
    *
    * @returns The current base URL configured in the client.
-   *          This URL typically represents the root endpoint of the Strapi service the SDK interfaces with.
+   *          This URL typically represents the root endpoint of the Strapi service the client interfaces with.
    *
    * @example
    * const config = { baseURL: 'http://localhost:1337/api' };
@@ -240,7 +240,7 @@ export class Strapi {
   }
 
   /**
-   * Executes an HTTP fetch request to a specified endpoint using the SDK HTTP client.
+   * Executes an HTTP fetch request to a specified endpoint using the client HTTP client.
    *
    * This method ensures authentication is handled before issuing requests and sets the necessary headers.
    *
@@ -249,7 +249,7 @@ export class Strapi {
    *
    * @example
    * ```typescript
-   * // Create the SDK instance
+   * // Create the client instance
    * const config = { baseURL: 'http://localhost:1337/api' };
    * const client = new Strapi(config);
    *
@@ -284,7 +284,7 @@ export class Strapi {
    *
    * @example
    * ```typescript
-   * // Initialize the SDK with required configuration
+   * // Initialize the client with required configuration
    * const config = { baseURL: 'http://localhost:1337/api' };
    * const client = new Strapi(config);
    *
@@ -326,7 +326,7 @@ export class Strapi {
    *
    * @example
    * ```typescript
-   * // Initialize the SDK with required configuration
+   * // Initialize the client with required configuration
    * const client = new Strapi({ baseURL: 'http://localhost:1337/api' });
    *
    * // Retrieve a SingleTypeManager for the 'homepage' resource

--- a/src/client.ts
+++ b/src/client.ts
@@ -32,7 +32,7 @@ export interface AuthConfig<T = unknown> {
 }
 
 /**
- * Class representing the Strapi SDK to interface with a Strapi backend.
+ * Class representing the Strapi Client to interface with a Strapi backend.
  *
  * This class integrates setting up configuration, validation, and handling
  * HTTP requests with authentication.
@@ -96,7 +96,7 @@ export class Strapi {
    *
    * This method ensures that the provided configuration for the SDK is valid by using the
    * internal SDK validator. It is invoked during the initialization process to confirm that
-   * all necessary parts are correctly configured before effectively using the SDK.
+   * all necessary parts are correctly configured before effectively using the client.
    *
    * @throws {StrapiInitializationError} If the configuration validation fails, indicating an issue with the SDK initialization process.
    *
@@ -109,7 +109,7 @@ export class Strapi {
    *     options: { token: 'your-token-here' }
    *   }
    * };
-   * const sdk = new Strapi(config);
+   * const client = new Strapi(config);
    *
    * // The preflightValidation is automatically called within the constructor
    * // to ensure the provided config is valid prior to any further setup.
@@ -128,7 +128,7 @@ export class Strapi {
   }
 
   /**
-   * Initializes the configuration settings for the SDK.
+   * Initializes the configuration settings for the client.
    *
    * @internal
    */
@@ -140,7 +140,7 @@ export class Strapi {
   }
 
   /**
-   * Initializes the HTTP client configuration for the SDK.
+   * Initializes the HTTP client configuration for the client.
    *
    * Sets up necessary HTTP interceptors to ensure consistent behavior:
    * - Adds default HTTP request headers.
@@ -166,7 +166,7 @@ export class Strapi {
   }
 
   /**
-   * Initializes the authentication configuration for the SDK.
+   * Initializes the authentication configuration for the client.
    *
    * Sets up authentication strategies and required HTTP interceptors to:
    * - Handle user authentication through the configured strategy.
@@ -209,7 +209,7 @@ export class Strapi {
   }
 
   /**
-   * Retrieves the authentication configuration for the Strapi SDK.
+   * Retrieves the authentication configuration for the Strapi client.
    *
    * @note This is a private property used internally within the SDK for configuring authentication in the HTTP layer.
    *
@@ -220,20 +220,20 @@ export class Strapi {
   }
 
   /**
-   * Retrieves the base URL of the Strapi SDK instance.
+   * Retrieves the base URL of the Strapi Client instance.
    *
    * This getter returns the `baseURL` property stored within the SDK's configuration object.
    *
-   * The base URL is used as the starting point for all HTTP requests initiated through the SDK.
+   * The base URL is used as the starting point for all HTTP requests initiated through the client.
    *
-   * @returns The current base URL configured in the SDK.
+   * @returns The current base URL configured in the client.
    *          This URL typically represents the root endpoint of the Strapi service the SDK interfaces with.
    *
    * @example
    * const config = { baseURL: 'http://localhost:1337/api' };
-   * const sdk = new Strapi(config);
+   * const client = new Strapi(config);
    *
-   * console.log(sdk.baseURL); // Output: http://localhost:1337
+   * console.log(client.baseURL); // Output: http://localhost:1337
    */
   public get baseURL(): string {
     return this._config.baseURL;
@@ -244,17 +244,17 @@ export class Strapi {
    *
    * This method ensures authentication is handled before issuing requests and sets the necessary headers.
    *
-   * @param url - The endpoint to fetch from, appended to the base URL of the SDK.
+   * @param url - The endpoint to fetch from, appended to the base URL of the client.
    * @param [init] - Optional initialization options for the request, such as headers or method type.
    *
    * @example
    * ```typescript
    * // Create the SDK instance
    * const config = { baseURL: 'http://localhost:1337/api' };
-   * const sdk = new Strapi(config);
+   * const client = new Strapi(config);
    *
    * // Perform a custom fetch query
-   * const response = await sdk.fetch('/categories');
+   * const response = await client.fetch('/categories');
    *
    * // Parse the categories into a readable JSON object
    * const categories = await response.json();
@@ -286,10 +286,10 @@ export class Strapi {
    * ```typescript
    * // Initialize the SDK with required configuration
    * const config = { baseURL: 'http://localhost:1337/api' };
-   * const sdk = new Strapi(config);
+   * const client = new Strapi(config);
    *
    * // Retrieve a CollectionTypeManager for the 'articles' resource
-   * const articles = sdk.collection('articles');
+   * const articles = client.collection('articles');
    *
    * // Example: find all articles
    * const allArticles = await articles.find();
@@ -327,10 +327,10 @@ export class Strapi {
    * @example
    * ```typescript
    * // Initialize the SDK with required configuration
-   * const sdk = new Strapi({ baseURL: 'http://localhost:1337/api' });
+   * const client = new Strapi({ baseURL: 'http://localhost:1337/api' });
    *
    * // Retrieve a SingleTypeManager for the 'homepage' resource
-   * const homepage = sdk.single('homepage');
+   * const homepage = client.single('homepage');
    *
    * // Example: fetch the homepage content in Spanish
    * const homepageContent = await homepage.find({ locale: 'es' });

--- a/src/errors/strapi.ts
+++ b/src/errors/strapi.ts
@@ -1,7 +1,7 @@
 export class StrapiError extends Error {
   constructor(
     cause: unknown = undefined,
-    message: string = 'An error occurred in the Strapi SDK. Please check the logs for more information.'
+    message: string = 'An error occurred in the Strapi client. Please check the logs for more information.'
   ) {
     super(message);
 
@@ -19,7 +19,10 @@ export class StrapiValidationError extends StrapiError {
 }
 
 export class StrapiInitializationError extends StrapiError {
-  constructor(cause: unknown = undefined, message: string = 'Could not initialize the Strapi SDK') {
+  constructor(
+    cause: unknown = undefined,
+    message: string = 'Could not initialize the Strapi Client'
+  ) {
     super(cause, message);
   }
 }

--- a/src/http/client.ts
+++ b/src/http/client.ts
@@ -21,7 +21,7 @@ import type { HttpClientConfig, InterceptorManagerMap } from './types';
 const debug = createDebug('strapi:http');
 
 /**
- * Strapi SDK's HTTP Client
+ * Strapi Client's HTTP Client
  *
  * Provides methods for configuring the base URL, timeout, interceptors, headers,
  * and for performing HTTP requests with automatic URL validation.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { ApiTokenAuthProvider } from './auth';
-import { Strapi } from './sdk';
+import { Strapi } from './client';
 
-import type { StrapiConfig } from './sdk';
+import type { StrapiConfig } from './client';
 
 export interface Config {
   /**
@@ -40,19 +40,19 @@ export interface Config {
 }
 
 /**
- * Creates a new instance of the Strapi SDK with a specified configuration.
+ * Creates a new instance of the Strapi Client with a specified configuration.
  *
- * The Strapi SDK functions as a client library to interface with the Strapi content API.
+ * The Strapi Client functions as a client library to interface with the Strapi content API.
  *
  * It facilitates reliable and secure interactions with Strapi's APIs by handling URL validation,
  * request dispatch, and response parsing for content management.
  *
- * @param config - The configuration for initializing the SDK. This should include the base URL
+ * @param config - The configuration for initializing the client. This should include the base URL
  *                 of the Strapi content API that the SDK communicates with. The baseURL
  *                 must be formatted with one of the supported protocols: `http` or `https`.
  *                 Additionally, optional authentication details can be specified within the config.
  *
- * @returns An instance of the Strapi SDK configured with the specified baseURL and auth settings.
+ * @returns An instance of the Strapi Client configured with the specified baseURL and auth settings.
  *
  * @example
  * ```typescript
@@ -63,10 +63,10 @@ export interface Config {
  * };
  *
  * // Create the SDK instance
- * const sdk = strapi(config);
+ * const client = strapi(config);
  *
  * // Using the SDK to fetch content from a custom endpoint
- * const response = await sdk.fetch('/content-endpoint');
+ * const response = await client.fetch('/content-endpoint');
  * const data = await response.json();
  *
  * console.log(data);
@@ -97,5 +97,5 @@ export const strapi = (config: Config) => {
 export * from './errors';
 
 // Public types and interfaces
-export type { StrapiConfig, Strapi } from './sdk';
+export type { StrapiConfig, Strapi } from './client';
 export type { CollectionTypeManager, SingleTypeManager } from './content-types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export interface Config {
   /**
    * The base URL of the Strapi content API.
    *
-   * This specifies where the SDK should send requests.
+   * This specifies where the client should send requests.
    *
    * The URL must include the protocol (`http` or `https`) and serve
    * as the root path for all later API operations.
@@ -30,10 +30,10 @@ export interface Config {
    * @remarks
    * - A valid token must be a non-empty string.
    *
-   * - If the token is invalid or improperly formatted, the SDK
+   * - If the token is invalid or improperly formatted, the client
    * throws a `StrapiValidationError` during initialization.
    *
-   * - If excluded, the SDK operates without authentication.
+   * - If excluded, the client operates without authentication.
    */
 
   auth?: string;
@@ -48,7 +48,7 @@ export interface Config {
  * request dispatch, and response parsing for content management.
  *
  * @param config - The configuration for initializing the client. This should include the base URL
- *                 of the Strapi content API that the SDK communicates with. The baseURL
+ *                 of the Strapi content API that the client communicates with. The baseURL
  *                 must be formatted with one of the supported protocols: `http` or `https`.
  *                 Additionally, optional authentication details can be specified within the config.
  *
@@ -62,10 +62,10 @@ export interface Config {
  *   auth: 'your_token_here',
  * };
  *
- * // Create the SDK instance
+ * // Create the client instance
  * const client = strapi(config);
  *
- * // Using the SDK to fetch content from a custom endpoint
+ * // Using the client to fetch content from a custom endpoint
  * const response = await client.fetch('/content-endpoint');
  * const data = await response.json();
  *
@@ -78,19 +78,19 @@ export interface Config {
 export const strapi = (config: Config) => {
   const { baseURL, auth } = config;
 
-  const sdkConfig: StrapiConfig = { baseURL };
+  const clientConfig: StrapiConfig = { baseURL };
 
   // In this factory, while there is only one auth strategy available, users can't manually set the strategy options.
-  // Since the SDK constructor needs to define a proper strategy,
+  // Since the client constructor needs to define a proper strategy,
   // it is handled here if the auth property is provided
   if (auth !== undefined) {
-    sdkConfig.auth = {
+    clientConfig.auth = {
       strategy: ApiTokenAuthProvider.identifier,
       options: { token: auth },
     };
   }
 
-  return new Strapi(sdkConfig);
+  return new Strapi(clientConfig);
 };
 
 // Error classes

--- a/src/validators/client.ts
+++ b/src/validators/client.ts
@@ -4,12 +4,12 @@ import { StrapiValidationError, URLValidationError } from '../errors';
 
 import { URLValidator } from './url';
 
-import type { StrapiConfig } from '../sdk';
+import type { StrapiConfig } from '../client';
 
 const debug = createDebug('strapi:validators:config');
 
 /**
- * Provides the ability to validate the configuration used for initializing the Strapi SDK.
+ * Provides the ability to validate the configuration used for initializing the Strapi client.
  *
  * This includes URL validation to ensure compatibility with Strapi's API endpoints.
  */
@@ -27,7 +27,7 @@ export class StrapiConfigValidator {
    * Validates the provided SDK configuration, ensuring that all values are
    * suitable for the SDK operations..
    *
-   * @param config - The configuration object for the Strapi SDK. Must include a `baseURL` property indicating the API's endpoint.
+   * @param config - The configuration object for the Strapi client. Must include a `baseURL` property indicating the API's endpoint.
    *
    * @throws {StrapiValidationError} If the configuration is invalid, or if the baseURL is invalid.
    */

--- a/src/validators/client.ts
+++ b/src/validators/client.ts
@@ -24,15 +24,15 @@ export class StrapiConfigValidator {
   }
 
   /**
-   * Validates the provided SDK configuration, ensuring that all values are
-   * suitable for the SDK operations..
+   * Validates the provided client configuration, ensuring that all values are
+   * suitable for the client operations..
    *
    * @param config - The configuration object for the Strapi client. Must include a `baseURL` property indicating the API's endpoint.
    *
    * @throws {StrapiValidationError} If the configuration is invalid, or if the baseURL is invalid.
    */
   validateConfig(config: StrapiConfig) {
-    debug('validating sdk config');
+    debug('validating client config');
 
     if (
       config === undefined ||
@@ -40,7 +40,7 @@ export class StrapiConfigValidator {
       Array.isArray(config) ||
       typeof config !== 'object'
     ) {
-      debug(`provided sdk configuration is not a valid object: %o (%s)`, config, typeof config);
+      debug(`provided client configuration is not a valid object: %o (%s)`, config, typeof config);
 
       throw new StrapiValidationError(
         new TypeError('The provided configuration is not a valid object.')
@@ -49,7 +49,7 @@ export class StrapiConfigValidator {
 
     this.validateBaseURL(config.baseURL);
 
-    debug('validated sdk config successfully');
+    debug('validated client config successfully');
   }
 
   /**
@@ -65,7 +65,7 @@ export class StrapiConfigValidator {
       this._urlValidator.validate(url);
     } catch (e) {
       if (e instanceof URLValidationError) {
-        debug('failed to validate sdk config, invalid base url %o', url);
+        debug('failed to validate client config, invalid base url %o', url);
         throw new StrapiValidationError(e);
       }
 

--- a/src/validators/index.ts
+++ b/src/validators/index.ts
@@ -1,2 +1,2 @@
-export { StrapiConfigValidator } from './sdk';
+export { StrapiConfigValidator } from './client';
 export { URLValidator } from './url';

--- a/tests/unit/client.test.ts
+++ b/tests/unit/client.test.ts
@@ -10,9 +10,9 @@ import {
   StrapiInitializationError,
   StrapiValidationError,
 } from '../../src';
+import { Strapi } from '../../src/client';
 import { CollectionTypeManager, SingleTypeManager } from '../../src/content-types';
 import { HttpClient, StatusCode } from '../../src/http';
-import { Strapi } from '../../src/sdk';
 import { StrapiConfigValidator } from '../../src/validators';
 
 import {
@@ -23,8 +23,8 @@ import {
   MockFlakyURLValidator,
 } from './mocks';
 
+import type { StrapiConfig } from '../../src/client';
 import type { HttpClientConfig } from '../../src/http';
-import type { StrapiConfig } from '../../src/sdk';
 
 describe('Strapi', () => {
   const mockHttpClientFactory = (config: HttpClientConfig) => new MockHttpClient(config);
@@ -58,11 +58,11 @@ describe('Strapi', () => {
       const authSetStrategySpy = jest.spyOn(MockAuthManager.prototype, 'setStrategy');
 
       // Act
-      const sdk = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
+      const client = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
 
       // Assert
 
-      expect(sdk).toBeInstanceOf(Strapi);
+      expect(client).toBeInstanceOf(Strapi);
       expect(validatorSpy).toHaveBeenCalledWith(config);
       expect(authSetStrategySpy).toHaveBeenCalledWith(MockAuthProvider.identifier, undefined);
     });
@@ -77,10 +77,10 @@ describe('Strapi', () => {
       const authSetStrategySpy = jest.spyOn(MockAuthManager.prototype, 'setStrategy');
 
       // Act
-      const sdk = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
+      const client = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
 
       // Assert
-      expect(sdk).toBeInstanceOf(Strapi);
+      expect(client).toBeInstanceOf(Strapi);
       expect(authSetStrategySpy).not.toHaveBeenCalled();
     });
 
@@ -130,7 +130,7 @@ describe('Strapi', () => {
 
     it('should fail to create and SDK instance if there is an unexpected error', () => {
       // Arrange
-      let sdk!: Strapi;
+      let client!: Strapi;
 
       const baseURL = 'https://example.com';
       const config: StrapiConfig = { baseURL } satisfies StrapiConfig;
@@ -139,14 +139,14 @@ describe('Strapi', () => {
       const validateSpy = jest.spyOn(MockFlakyURLValidator.prototype, 'validate');
 
       // Act
-      const instantiateSDK = () => {
-        sdk = new Strapi(config, new StrapiConfigValidator(new MockFlakyURLValidator()));
+      const instantiateClient = () => {
+        client = new Strapi(config, new StrapiConfigValidator(new MockFlakyURLValidator()));
       };
 
       // Assert
-      expect(instantiateSDK).toThrow(expectedError);
+      expect(instantiateClient).toThrow(expectedError);
 
-      expect(sdk).toBeUndefined();
+      expect(client).toBeUndefined();
 
       expect(validateSpy).toHaveBeenCalledTimes(1);
       expect(validateSpy).toHaveBeenCalledWith(baseURL);
@@ -154,10 +154,10 @@ describe('Strapi', () => {
 
     it('should initialize correctly with the default validator', () => {
       // Arrange
-      const sdk = new Strapi({ baseURL: 'https://localhost:1337/api' });
+      const client = new Strapi({ baseURL: 'https://localhost:1337/api' });
 
       // Act & Assert
-      expect(sdk).toBeInstanceOf(Strapi);
+      expect(client).toBeInstanceOf(Strapi);
     });
   });
 
@@ -170,10 +170,10 @@ describe('Strapi', () => {
       const mockValidator = new MockStrapiConfigValidator();
       const mockAuthManager = new MockAuthManager();
 
-      const sdk = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
+      const client = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
 
       // Act
-      const collection = sdk.collection(resource);
+      const collection = client.collection(resource);
 
       // Assert
       expect(collection).toBeInstanceOf(CollectionTypeManager);
@@ -190,10 +190,10 @@ describe('Strapi', () => {
       const mockValidator = new MockStrapiConfigValidator();
       const mockAuthManager = new MockAuthManager();
 
-      const sdk = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
+      const client = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
 
       // Act
-      const single = sdk.single(resource);
+      const single = client.single(resource);
 
       // Assert
       expect(single).toBeInstanceOf(SingleTypeManager);
@@ -211,12 +211,12 @@ describe('Strapi', () => {
         const mockValidator = new MockStrapiConfigValidator();
         const mockAuthManager = new MockAuthManager();
 
-        const sdk = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
+        const client = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
 
         const fetchSpy = jest.spyOn(MockHttpClient.prototype, 'fetch');
 
         // Act
-        await sdk.fetch(path);
+        await client.fetch(path);
         const headers = fetchSpy.mock.lastCall?.[1]?.headers;
 
         // Assert
@@ -239,12 +239,12 @@ describe('Strapi', () => {
         const mockValidator = new MockStrapiConfigValidator();
         const mockAuthManager = new MockAuthManager();
 
-        const sdk = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
+        const client = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
 
         const fetchSpy = jest.spyOn(MockHttpClient.prototype, 'fetch');
 
         // Act
-        await sdk.fetch(path, init);
+        await client.fetch(path, init);
         const headers = fetchSpy.mock.lastCall?.[1]?.headers;
 
         // Assert
@@ -269,7 +269,7 @@ describe('Strapi', () => {
         const mockValidator = new MockStrapiConfigValidator();
         const mockAuthManager = new MockAuthManager();
 
-        const sdk = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
+        const client = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
 
         jest
           .spyOn(MockHttpClient.prototype, 'fetch')
@@ -277,7 +277,7 @@ describe('Strapi', () => {
           .mockImplementationOnce(() => Promise.resolve(new Response(null, { status })));
 
         // Act & Assert
-        await expect(sdk.fetch(path)).rejects.toThrow(error);
+        await expect(client.fetch(path)).rejects.toThrow(error);
       });
     });
 
@@ -294,10 +294,10 @@ describe('Strapi', () => {
 
         const authenticateSpy = jest.spyOn(MockAuthManager.prototype, 'authenticate');
 
-        const sdk = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
+        const client = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
 
         // Act
-        await sdk.fetch('/');
+        await client.fetch('/');
 
         // Assert
         expect(authenticateSpy).toHaveBeenCalledWith(expect.any(HttpClient));
@@ -315,10 +315,10 @@ describe('Strapi', () => {
 
         const authenticateRequestSpy = jest.spyOn(MockAuthManager.prototype, 'authenticateRequest');
 
-        const sdk = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
+        const client = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
 
         // Act
-        await sdk.fetch('/');
+        await client.fetch('/');
 
         // Assert
         expect(authenticateRequestSpy).toHaveBeenCalledWith(expect.any(Request));
@@ -339,10 +339,10 @@ describe('Strapi', () => {
 
         const authenticateRequestSpy = jest.spyOn(MockAuthManager.prototype, 'authenticateRequest');
 
-        const sdk = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
+        const client = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
 
         // Act
-        await sdk.fetch('/');
+        await client.fetch('/');
 
         // Assert
         expect(authenticateRequestSpy).toHaveBeenCalledWith(expect.any(Request));
@@ -364,7 +364,7 @@ describe('Strapi', () => {
         const mockValidator = new MockStrapiConfigValidator();
         const mockAuthManager = new MockAuthManager();
 
-        const sdk = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
+        const client = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
 
         const spies = {
           authenticate: jest.spyOn(MockAuthManager.prototype, 'authenticate'),
@@ -378,7 +378,7 @@ describe('Strapi', () => {
           .mockImplementation(() => Promise.resolve(new Response('Unauthorized', { status: 401 })));
 
         // Act & Assert
-        await expect(sdk.fetch('/')).rejects.toThrow(HTTPAuthorizationError);
+        await expect(client.fetch('/')).rejects.toThrow(HTTPAuthorizationError);
 
         expect(spies.authenticate).toHaveBeenCalledWith(expect.any(HttpClient));
         expect(spies.authenticateRequest).toHaveBeenCalledWith(expect.any(Request));
@@ -399,10 +399,10 @@ describe('Strapi', () => {
 
     const mockValidator = new MockStrapiConfigValidator();
     const mockAuthManager = new MockAuthManager();
-    const sdk = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
+    const client = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
 
     // Act
-    const response = await sdk.fetch('/data');
+    const response = await client.fetch('/data');
 
     // Assert
     expect(requestSpy).toHaveBeenCalledWith('/data', undefined);
@@ -416,10 +416,10 @@ describe('Strapi', () => {
     const mockValidator = new MockStrapiConfigValidator();
     const mockAuthManager = new MockAuthManager();
 
-    const sdk = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
+    const client = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
 
     // Act
-    const { baseURL } = sdk;
+    const { baseURL } = client;
 
     // Assert
     expect(baseURL).toBe(config.baseURL);

--- a/tests/unit/client.test.ts
+++ b/tests/unit/client.test.ts
@@ -128,7 +128,7 @@ describe('Strapi', () => {
       expect(validateConfigSpy).toHaveBeenCalledWith(config);
     });
 
-    it('should fail to create and SDK instance if there is an unexpected error', () => {
+    it('should fail to create and client instance if there is an unexpected error', () => {
       // Arrange
       let client!: Strapi;
 

--- a/tests/unit/errors/client-errors.test.ts
+++ b/tests/unit/errors/client-errors.test.ts
@@ -8,7 +8,7 @@ describe('Strapi Errors', () => {
 
       // Assert
       expect(error.message).toBe(
-        'An error occurred in the Strapi SDK. Please check the logs for more information.'
+        'An error occurred in the Strapi client. Please check the logs for more information.'
       );
       expect(error.cause).toBeUndefined();
     });
@@ -75,7 +75,7 @@ describe('Strapi Errors', () => {
       const error = new StrapiInitializationError();
 
       // Assert
-      expect(error.message).toBe('Could not initialize the Strapi SDK');
+      expect(error.message).toBe('Could not initialize the Strapi Client');
       expect(error.cause).toBeUndefined();
     });
 

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -10,11 +10,11 @@ describe('strapi', () => {
     const config = { baseURL: 'https://api.example.com' } satisfies Config;
 
     // Act
-    const sdk = strapi(config);
+    const client = strapi(config);
 
     // Assert
-    expect(sdk).toBeInstanceOf(Strapi);
-    expect(sdk).toHaveProperty('baseURL', config.baseURL);
+    expect(client).toBeInstanceOf(Strapi);
+    expect(client).toHaveProperty('baseURL', config.baseURL);
   });
 
   it('should create an SDK instance with valid auth configuration', () => {
@@ -23,11 +23,11 @@ describe('strapi', () => {
     const config = { baseURL: 'https://api.example.com', auth: token } satisfies Config;
 
     // Act
-    const sdk = strapi(config);
+    const client = strapi(config);
 
     // Assert
-    expect(sdk).toBeInstanceOf(Strapi);
-    expect(sdk).toHaveProperty('auth', {
+    expect(client).toBeInstanceOf(Strapi);
+    expect(client).toHaveProperty('auth', {
       strategy: ApiTokenAuthProvider.identifier, // default auth strategy
       options: { token },
     });

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -1,6 +1,6 @@
 import { strapi, StrapiInitializationError } from '../../src';
 import { ApiTokenAuthProvider } from '../../src/auth';
-import { Strapi } from '../../src/sdk';
+import { Strapi } from '../../src/client';
 
 import type { Config } from '../../src';
 

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -5,7 +5,7 @@ import { Strapi } from '../../src/client';
 import type { Config } from '../../src';
 
 describe('strapi', () => {
-  it('should create an SDK instance with valid http configuration', () => {
+  it('should create an client instance with valid http configuration', () => {
     // Arrange
     const config = { baseURL: 'https://api.example.com' } satisfies Config;
 
@@ -17,7 +17,7 @@ describe('strapi', () => {
     expect(client).toHaveProperty('baseURL', config.baseURL);
   });
 
-  it('should create an SDK instance with valid auth configuration', () => {
+  it('should create an client instance with valid auth configuration', () => {
     // Arrange
     const token = '<token>';
     const config = { baseURL: 'https://api.example.com', auth: token } satisfies Config;

--- a/tests/unit/validators/strapi-config.test.ts
+++ b/tests/unit/validators/strapi-config.test.ts
@@ -1,7 +1,7 @@
 import { StrapiValidationError, URLValidationError } from '../../../src';
 import { StrapiConfigValidator, URLValidator } from '../../../src/validators';
 
-import type { StrapiConfig } from '../../../src/sdk';
+import type { StrapiConfig } from '../../../src/client';
 
 describe('Strapi Config Validator', () => {
   let urlValidatorMock: jest.Mocked<URLValidator>;


### PR DESCRIPTION
### What does it do?

Renames the project and all references to it from `sdk-js` to `client`

### Why is it needed?

`sdk-js` was redundant and unclear what the project was about

### How to test it?

Everything should work as before, except with the new package name

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
