### PR TITLE
chore: fix debug string and do not autoopen demo admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ You can turn on or off debug logs using the `DEBUG` environment variable:
 DEBUG=*
 
 # Enable logs for a specific namespace
-DEBUG=sdk:http
+DEBUG=strapi:http
 
 # Turn off logs
 unset DEBUG

--- a/demo/.strapi-app/config/admin.ts
+++ b/demo/.strapi-app/config/admin.ts
@@ -14,4 +14,5 @@ export default ({ env }) => ({
     nps: env.bool('FLAG_NPS', true),
     promoteEE: env.bool('FLAG_PROMOTE_EE', true),
   },
+  autoOpen: false,
 });


### PR DESCRIPTION
### What does it do?

- there is no `sdk:http` so I replaced with the correct`strapi:http`
-  do not autoopen demo admin

### Why is it needed?

Describe the issue you are solving.

### How to test it?

Provide information about the environment and the path to verify the behaviour.

### Related issue(s)/PR(s)

Let us know if this is related to any issue/pull request
