### PR TITLE
fix(build): force browser-compatible module resolution in builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,15 +27,17 @@
       "url": "https://strapi.io"
     }
   ],
-  "browser": "./dist/bundle.browser.min.js",
+  "browser": "./dist/bundle.iife.min.js",
   "exports": {
     ".": {
       "types": "./dist/exports.d.ts",
-      "require": "./dist/bundle.cjs",
-      "import": "./dist/bundle.mjs",
       "browser": {
-        "import": "./dist/bundle.browser.min.js",
-        "require": "./dist/bundle.browser.min.js"
+        "import": "./dist/bundle.browser.mjs",
+        "require": "./dist/bundle.browser.cjs"
+      },
+      "node": {
+        "require": "./dist/bundle.cjs",
+        "import": "./dist/bundle.mjs"
       }
     },
     "./package.json": "./package.json"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
       "url": "https://strapi.io"
     }
   ],
-  "browser": "./dist/bundle.iife.min.js",
+  "browser": "./dist/bundle.browser.iife.min.js",
   "exports": {
     ".": {
       "types": "./dist/exports.d.ts",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -51,7 +51,7 @@ const node_build = {
     }),
     // Convert CommonJS modules to ES6, so they can be included in a Rollup bundle
     commonjs(),
-    // Transpile TypeScript to JavaScript
+    // Transpile
     typescript({ tsconfig: './tsconfig.build.json' }),
     // Replace environment variables
     replace({
@@ -102,7 +102,7 @@ const browser_build = {
     }),
     // Convert CommonJS modules to ES6, so they can be included in a Rollup bundle
     commonjs(),
-    // Transpile TypeScript to JavaScript
+    // Transpile
     typescript({ tsconfig: './tsconfig.build.json' }),
     // Replace environment variables and add process.browser
     replace({
@@ -132,7 +132,7 @@ const iife_build = {
   cache: true,
   output: [
     {
-      file: 'dist/bundle.iife.min.js',
+      file: 'dist/bundle.browser.iife.min.js',
       format: 'iife',
       name: 'strapi',
       sourcemap: true,
@@ -150,7 +150,7 @@ const iife_build = {
     }),
     // Convert CommonJS modules to ES6, so they can be included in a Rollup bundle
     commonjs(),
-    // Transpile TypeScript to JavaScript
+    // Transpile
     typescript({ tsconfig: './tsconfig.build.json' }),
     // Replace environment variables and add process.browser for browser-specific code
     replace({

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -51,7 +51,7 @@ const node_build = {
   plugins: [
     // Locate modules using the Node resolution algorithm, for using third party modules in node_modules
     nodeResolve({
-      browser: false, // "browser" properties in package files are ignored
+      browser: true, // Only resolve browser-compatible modules
       preferBuiltins: true, // Prefer built-in modules
     }),
     // Convert CommonJS modules to ES6, so they can be included in a Rollup bundle


### PR DESCRIPTION
### What does it do?

Force to only resolve browser-compatible modules at build time, for both browser and node builds

### Why is it needed?

Fix issues encountered when using the client with client-side framework like react or angular.

### Related issue(s)/PR(s)

fix #69 
fix #62 
fix #61 (to be tested)
