### PR TITLE
enhancement(client): rename Strapi to StrapiClient 

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "browser": "./dist/bundle.browser.min.js",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/exports.d.ts",
       "require": "./dist/bundle.cjs",
       "import": "./dist/bundle.mjs",
       "browser": {

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -30,7 +30,7 @@ const isProduction = process.env.NODE_ENV === 'production';
  * @type {import('rollup').RollupOptions}
  */
 const node_build = {
-  input: 'src/index.ts',
+  input: 'src/exports.ts',
   cache: true,
   output: [
     // CommonJS build
@@ -90,7 +90,7 @@ const node_build = {
  * @type {import('rollup').RollupOptions}
  */
 const browser_build = {
-  input: 'src/index.ts',
+  input: 'src/exports.ts',
   cache: true,
   output: [
     {

--- a/src/client.ts
+++ b/src/client.ts
@@ -375,15 +375,3 @@ export class StrapiClient {
     return new SingleTypeManager(resource, this._httpClient);
   }
 }
-
-// Support for deprecated types
-
-/**
- * @deprecated This type will be removed in v2, consider using {@link StrapiClientConfig} as a replacement
- */
-export type StrapiConfig = StrapiClientConfig;
-
-/**
- * @deprecated This type will be removed in v2, consider using {@link StrapiClient} as a replacement
- */
-export type Strapi = StrapiClient;

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -1,0 +1,40 @@
+/**
+ * This file is used to export all the public symbols for the Strapi Client API.
+ */
+
+import type { StrapiClient, StrapiClientConfig } from './client';
+
+// ############################
+// #      Main Client API     #
+// ############################
+
+export { strapi, type Config } from './index';
+
+// ############################
+// #      Error Classes       #
+// ############################
+
+export * from './errors';
+
+// ############################
+// #   Public Utility Types   #
+// ############################
+
+export type { StrapiClientConfig, StrapiClient } from './client';
+export type { CollectionTypeManager, SingleTypeManager } from './content-types';
+export type { FilesManager, FileQueryParams, FileResponse, FileListResponse } from './files';
+
+// ############################
+// #    Deprecated symbols    #
+// # (backward compatibility) #
+// ############################
+
+/**
+ * @deprecated This type will be removed in v2, consider using {@link StrapiClientConfig} as a replacement
+ */
+export type StrapiConfig = StrapiClientConfig;
+
+/**
+ * @deprecated This type will be removed in v2, consider using {@link StrapiClient} as a replacement
+ */
+export type Strapi = StrapiClient;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { ApiTokenAuthProvider } from './auth';
-import { Strapi } from './client';
+import { StrapiClient } from './client';
 
-import type { StrapiConfig } from './client';
+import type { StrapiClientConfig } from './client';
 
 export interface Config {
   /**
@@ -78,7 +78,7 @@ export interface Config {
 export const strapi = (config: Config) => {
   const { baseURL, auth } = config;
 
-  const clientConfig: StrapiConfig = { baseURL };
+  const clientConfig: StrapiClientConfig = { baseURL };
 
   // In this factory, while there is only one auth strategy available, users can't manually set the strategy options.
   // Since the client constructor needs to define a proper strategy,
@@ -90,13 +90,19 @@ export const strapi = (config: Config) => {
     };
   }
 
-  return new Strapi(clientConfig);
+  return new StrapiClient(clientConfig);
 };
 
 // Error classes
 export * from './errors';
 
 // Public types and interfaces
-export type { StrapiConfig, Strapi } from './client';
+export type {
+  StrapiClientConfig,
+  StrapiClient,
+  // TODO: Remove deprecated symbols "Strapi" and "StrapiConfig" in v2
+  Strapi,
+  StrapiConfig,
+} from './client';
 export type { CollectionTypeManager, SingleTypeManager } from './content-types';
 export type { FilesManager, FileQueryParams, FileResponse, FileListResponse } from './files';

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,17 +92,3 @@ export const strapi = (config: Config) => {
 
   return new StrapiClient(clientConfig);
 };
-
-// Error classes
-export * from './errors';
-
-// Public types and interfaces
-export type {
-  StrapiClientConfig,
-  StrapiClient,
-  // TODO: Remove deprecated symbols "Strapi" and "StrapiConfig" in v2
-  Strapi,
-  StrapiConfig,
-} from './client';
-export type { CollectionTypeManager, SingleTypeManager } from './content-types';
-export type { FilesManager, FileQueryParams, FileResponse, FileListResponse } from './files';

--- a/src/validators/client.ts
+++ b/src/validators/client.ts
@@ -4,7 +4,7 @@ import { StrapiValidationError, URLValidationError } from '../errors';
 
 import { URLValidator } from './url';
 
-import type { StrapiConfig } from '../client';
+import type { StrapiClientConfig } from '../client';
 
 const debug = createDebug('strapi:validators:config');
 
@@ -31,7 +31,7 @@ export class StrapiConfigValidator {
    *
    * @throws {StrapiValidationError} If the configuration is invalid, or if the baseURL is invalid.
    */
-  validateConfig(config: StrapiConfig) {
+  validateConfig(config: StrapiClientConfig) {
     debug('validating client config');
 
     if (

--- a/tests/fixtures/http-error-associations.ts
+++ b/tests/fixtures/http-error-associations.ts
@@ -6,7 +6,7 @@ import {
   HTTPInternalServerError,
   HTTPNotFoundError,
   HTTPTimeoutError,
-} from '../../src';
+} from '../../src/errors';
 import { StatusCode } from '../../src/http';
 
 export const HTTP_ERROR_ASSOCIATIONS = [

--- a/tests/unit/auth/factory.test.ts
+++ b/tests/unit/auth/factory.test.ts
@@ -1,5 +1,5 @@
-import { StrapiError } from '../../../src';
 import { AuthProviderFactory } from '../../../src/auth';
+import { StrapiError } from '../../../src/errors';
 import { MockAuthProvider } from '../mocks';
 
 describe('AuthProviderFactory', () => {

--- a/tests/unit/auth/providers/api-token.test.ts
+++ b/tests/unit/auth/providers/api-token.test.ts
@@ -1,5 +1,5 @@
-import { StrapiValidationError } from '../../../../src';
 import { ApiTokenAuthProvider, ApiTokenAuthProviderOptions } from '../../../../src/auth';
+import { StrapiValidationError } from '../../../../src/errors';
 
 describe('ApiTokenAuthProvider', () => {
   describe('Name', () => {

--- a/tests/unit/auth/providers/users-permissions.test.ts
+++ b/tests/unit/auth/providers/users-permissions.test.ts
@@ -1,8 +1,8 @@
-import { HTTPBadRequestError, StrapiValidationError } from '../../../../src';
 import {
   UsersPermissionsAuthProvider,
   UsersPermissionsAuthProviderOptions,
 } from '../../../../src/auth';
+import { HTTPBadRequestError, StrapiValidationError } from '../../../../src/errors';
 import { MockHttpClient, mockRequest, mockResponse } from '../../mocks';
 
 const FAKE_TOKEN = '<token>';

--- a/tests/unit/client.test.ts
+++ b/tests/unit/client.test.ts
@@ -10,7 +10,7 @@ import {
   StrapiInitializationError,
   StrapiValidationError,
 } from '../../src';
-import { Strapi } from '../../src/client';
+import { StrapiClient } from '../../src/client';
 import { CollectionTypeManager, SingleTypeManager } from '../../src/content-types';
 import { HttpClient, StatusCode } from '../../src/http';
 import { StrapiConfigValidator } from '../../src/validators';
@@ -23,7 +23,7 @@ import {
   MockFlakyURLValidator,
 } from './mocks';
 
-import type { StrapiConfig } from '../../src/client';
+import type { StrapiClientConfig } from '../../src/client';
 import type { HttpClientConfig } from '../../src/http';
 
 describe('Strapi', () => {
@@ -49,7 +49,7 @@ describe('Strapi', () => {
       const config = {
         baseURL: 'https://localhost:1337/api',
         auth: { strategy: MockAuthProvider.identifier },
-      } satisfies StrapiConfig;
+      } satisfies StrapiClientConfig;
 
       const mockValidator = new MockStrapiConfigValidator();
       const mockAuthManager = new MockAuthManager();
@@ -58,18 +58,23 @@ describe('Strapi', () => {
       const authSetStrategySpy = jest.spyOn(MockAuthManager.prototype, 'setStrategy');
 
       // Act
-      const client = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
+      const client = new StrapiClient(
+        config,
+        mockValidator,
+        mockAuthManager,
+        mockHttpClientFactory
+      );
 
       // Assert
 
-      expect(client).toBeInstanceOf(Strapi);
+      expect(client).toBeInstanceOf(StrapiClient);
       expect(validatorSpy).toHaveBeenCalledWith(config);
       expect(authSetStrategySpy).toHaveBeenCalledWith(MockAuthProvider.identifier, undefined);
     });
 
     it('should not set the auth strategy if no auth config is provided', () => {
       // Arrange
-      const config = { baseURL: 'https://localhost:1337/api' } satisfies StrapiConfig;
+      const config = { baseURL: 'https://localhost:1337/api' } satisfies StrapiClientConfig;
 
       const mockValidator = new MockStrapiConfigValidator();
       const mockAuthManager = new MockAuthManager();
@@ -77,10 +82,15 @@ describe('Strapi', () => {
       const authSetStrategySpy = jest.spyOn(MockAuthManager.prototype, 'setStrategy');
 
       // Act
-      const client = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
+      const client = new StrapiClient(
+        config,
+        mockValidator,
+        mockAuthManager,
+        mockHttpClientFactory
+      );
 
       // Assert
-      expect(client).toBeInstanceOf(Strapi);
+      expect(client).toBeInstanceOf(StrapiClient);
       expect(authSetStrategySpy).not.toHaveBeenCalled();
     });
 
@@ -94,7 +104,7 @@ describe('Strapi', () => {
         const config = {
           baseURL: 'https://localhost:1337/api',
           auth: { strategy: MockAuthProvider.identifier },
-        } satisfies StrapiConfig;
+        } satisfies StrapiClientConfig;
 
         const mockValidator = new MockStrapiConfigValidator();
         const mockAuthManager = new MockAuthManager();
@@ -105,7 +115,7 @@ describe('Strapi', () => {
 
         // Act
         expect(
-          () => new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory)
+          () => new StrapiClient(config, mockValidator, mockAuthManager, mockHttpClientFactory)
         ).toThrow(StrapiInitializationError);
 
         expect(mockAuthManager.setStrategy).toHaveBeenCalledWith(
@@ -117,30 +127,30 @@ describe('Strapi', () => {
 
     it('should throw an error on invalid baseURL', () => {
       // Arrange
-      const config = { baseURL: 'invalid-url' } satisfies StrapiConfig;
+      const config = { baseURL: 'invalid-url' } satisfies StrapiClientConfig;
 
       const mockValidator = new MockStrapiConfigValidator();
 
       const validateConfigSpy = jest.spyOn(mockValidator, 'validateConfig');
 
       // Act & Assert
-      expect(() => new Strapi(config, mockValidator)).toThrow(StrapiInitializationError);
+      expect(() => new StrapiClient(config, mockValidator)).toThrow(StrapiInitializationError);
       expect(validateConfigSpy).toHaveBeenCalledWith(config);
     });
 
     it('should fail to create and client instance if there is an unexpected error', () => {
       // Arrange
-      let client!: Strapi;
+      let client!: StrapiClient;
 
       const baseURL = 'https://example.com';
-      const config: StrapiConfig = { baseURL } satisfies StrapiConfig;
+      const config = { baseURL } satisfies StrapiClientConfig;
       const expectedError = new StrapiInitializationError(new Error('Unexpected error'));
 
       const validateSpy = jest.spyOn(MockFlakyURLValidator.prototype, 'validate');
 
       // Act
       const instantiateClient = () => {
-        client = new Strapi(config, new StrapiConfigValidator(new MockFlakyURLValidator()));
+        client = new StrapiClient(config, new StrapiConfigValidator(new MockFlakyURLValidator()));
       };
 
       // Assert
@@ -154,10 +164,10 @@ describe('Strapi', () => {
 
     it('should initialize correctly with the default validator', () => {
       // Arrange
-      const client = new Strapi({ baseURL: 'https://localhost:1337/api' });
+      const client = new StrapiClient({ baseURL: 'https://localhost:1337/api' });
 
       // Act & Assert
-      expect(client).toBeInstanceOf(Strapi);
+      expect(client).toBeInstanceOf(StrapiClient);
     });
   });
 
@@ -165,12 +175,17 @@ describe('Strapi', () => {
     it('should return a new CollectionTypeManager instance when given a resource name', () => {
       // Arrange
       const resource = 'articles';
-      const config = { baseURL: 'https://localhost:1337/api' } satisfies StrapiConfig;
+      const config = { baseURL: 'https://localhost:1337/api' } satisfies StrapiClientConfig;
 
       const mockValidator = new MockStrapiConfigValidator();
       const mockAuthManager = new MockAuthManager();
 
-      const client = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
+      const client = new StrapiClient(
+        config,
+        mockValidator,
+        mockAuthManager,
+        mockHttpClientFactory
+      );
 
       // Act
       const collection = client.collection(resource);
@@ -185,12 +200,17 @@ describe('Strapi', () => {
     it('should return a new SingleTypeManager instance when given a resource name', () => {
       // Arrange
       const resource = 'homepage';
-      const config = { baseURL: 'https://localhost:1337/api' } satisfies StrapiConfig;
+      const config = { baseURL: 'https://localhost:1337/api' } satisfies StrapiClientConfig;
 
       const mockValidator = new MockStrapiConfigValidator();
       const mockAuthManager = new MockAuthManager();
 
-      const client = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
+      const client = new StrapiClient(
+        config,
+        mockValidator,
+        mockAuthManager,
+        mockHttpClientFactory
+      );
 
       // Act
       const single = client.single(resource);
@@ -206,12 +226,17 @@ describe('Strapi', () => {
       it('fetch should add an application/json Content-Type header to each request', async () => {
         // Arrange
         const path = '/homepage';
-        const config = { baseURL: 'https://localhost:1337/api' } satisfies StrapiConfig;
+        const config = { baseURL: 'https://localhost:1337/api' } satisfies StrapiClientConfig;
 
         const mockValidator = new MockStrapiConfigValidator();
         const mockAuthManager = new MockAuthManager();
 
-        const client = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
+        const client = new StrapiClient(
+          config,
+          mockValidator,
+          mockAuthManager,
+          mockHttpClientFactory
+        );
 
         const fetchSpy = jest.spyOn(MockHttpClient.prototype, 'fetch');
 
@@ -234,7 +259,7 @@ describe('Strapi', () => {
         const path = '/upload';
         const contentType = 'multipart/form-data';
 
-        const config = { baseURL: 'https://localhost:1337/api' } satisfies StrapiConfig;
+        const config = { baseURL: 'https://localhost:1337/api' } satisfies StrapiClientConfig;
         const init = {
           method: 'POST',
           headers: { 'Content-Type': contentType },
@@ -243,7 +268,12 @@ describe('Strapi', () => {
         const mockValidator = new MockStrapiConfigValidator();
         const mockAuthManager = new MockAuthManager();
 
-        const client = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
+        const client = new StrapiClient(
+          config,
+          mockValidator,
+          mockAuthManager,
+          mockHttpClientFactory
+        );
 
         const fetchSpy = jest.spyOn(MockHttpClient.prototype, 'fetch');
 
@@ -272,12 +302,17 @@ describe('Strapi', () => {
       ])('should throw an HTTP exception on %s error', async (_name, status, error) => {
         // Arrange
         const path = '/homepage';
-        const config = { baseURL: 'https://localhost:1337/api' } satisfies StrapiConfig;
+        const config = { baseURL: 'https://localhost:1337/api' } satisfies StrapiClientConfig;
 
         const mockValidator = new MockStrapiConfigValidator();
         const mockAuthManager = new MockAuthManager();
 
-        const client = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
+        const client = new StrapiClient(
+          config,
+          mockValidator,
+          mockAuthManager,
+          mockHttpClientFactory
+        );
 
         jest
           .spyOn(MockHttpClient.prototype, 'fetch')
@@ -295,14 +330,19 @@ describe('Strapi', () => {
         const config = {
           baseURL: 'https://localhost:1337/api',
           auth: { strategy: MockAuthProvider.identifier },
-        } satisfies StrapiConfig;
+        } satisfies StrapiClientConfig;
 
         const mockValidator = new MockStrapiConfigValidator();
         const mockAuthManager = new MockAuthManager();
 
         const authenticateSpy = jest.spyOn(MockAuthManager.prototype, 'authenticate');
 
-        const client = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
+        const client = new StrapiClient(
+          config,
+          mockValidator,
+          mockAuthManager,
+          mockHttpClientFactory
+        );
 
         // Act
         await client.fetch('/');
@@ -316,14 +356,19 @@ describe('Strapi', () => {
         const config = {
           baseURL: 'https://localhost:1337/api',
           auth: { strategy: MockAuthProvider.identifier },
-        } satisfies StrapiConfig;
+        } satisfies StrapiClientConfig;
 
         const mockValidator = new MockStrapiConfigValidator();
         const mockAuthManager = new MockAuthManager();
 
         const authenticateRequestSpy = jest.spyOn(MockAuthManager.prototype, 'authenticateRequest');
 
-        const client = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
+        const client = new StrapiClient(
+          config,
+          mockValidator,
+          mockAuthManager,
+          mockHttpClientFactory
+        );
 
         // Act
         await client.fetch('/');
@@ -340,14 +385,19 @@ describe('Strapi', () => {
 
       it(`shouldn't authenticates outgoing HTTP requests if no auth strategy is set`, async () => {
         // Arrange
-        const config = { baseURL: 'https://localhost:1337/api' } satisfies StrapiConfig;
+        const config = { baseURL: 'https://localhost:1337/api' } satisfies StrapiClientConfig;
 
         const mockValidator = new MockStrapiConfigValidator();
         const mockAuthManager = new MockAuthManager();
 
         const authenticateRequestSpy = jest.spyOn(MockAuthManager.prototype, 'authenticateRequest');
 
-        const client = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
+        const client = new StrapiClient(
+          config,
+          mockValidator,
+          mockAuthManager,
+          mockHttpClientFactory
+        );
 
         // Act
         await client.fetch('/');
@@ -367,12 +417,17 @@ describe('Strapi', () => {
         const config = {
           baseURL: 'https://localhost:1337/api',
           auth: { strategy: MockAuthProvider.identifier },
-        } satisfies StrapiConfig;
+        } satisfies StrapiClientConfig;
 
         const mockValidator = new MockStrapiConfigValidator();
         const mockAuthManager = new MockAuthManager();
 
-        const client = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
+        const client = new StrapiClient(
+          config,
+          mockValidator,
+          mockAuthManager,
+          mockHttpClientFactory
+        );
 
         const spies = {
           authenticate: jest.spyOn(MockAuthManager.prototype, 'authenticate'),
@@ -401,13 +456,13 @@ describe('Strapi', () => {
 
   it('should fetch data correctly with fetch method', async () => {
     // Arrange
-    const config = { baseURL: 'https://localhost:1337/api' } satisfies StrapiConfig;
+    const config = { baseURL: 'https://localhost:1337/api' } satisfies StrapiClientConfig;
 
     const requestSpy = jest.spyOn(MockHttpClient.prototype, 'request');
 
     const mockValidator = new MockStrapiConfigValidator();
     const mockAuthManager = new MockAuthManager();
-    const client = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
+    const client = new StrapiClient(config, mockValidator, mockAuthManager, mockHttpClientFactory);
 
     // Act
     const response = await client.fetch('/data');
@@ -419,12 +474,12 @@ describe('Strapi', () => {
 
   it('should retrieve baseURL correctly from config', () => {
     // Arrange
-    const config = { baseURL: 'https://localhost:1337/api' } satisfies StrapiConfig;
+    const config = { baseURL: 'https://localhost:1337/api' } satisfies StrapiClientConfig;
 
     const mockValidator = new MockStrapiConfigValidator();
     const mockAuthManager = new MockAuthManager();
 
-    const client = new Strapi(config, mockValidator, mockAuthManager, mockHttpClientFactory);
+    const client = new StrapiClient(config, mockValidator, mockAuthManager, mockHttpClientFactory);
 
     // Act
     const { baseURL } = client;

--- a/tests/unit/client.test.ts
+++ b/tests/unit/client.test.ts
@@ -1,3 +1,5 @@
+import { StrapiClient } from '../../src/client';
+import { CollectionTypeManager, SingleTypeManager } from '../../src/content-types';
 import {
   HTTPAuthorizationError,
   HTTPBadRequestError,
@@ -9,9 +11,7 @@ import {
   StrapiError,
   StrapiInitializationError,
   StrapiValidationError,
-} from '../../src';
-import { StrapiClient } from '../../src/client';
-import { CollectionTypeManager, SingleTypeManager } from '../../src/content-types';
+} from '../../src/errors';
 import { HttpClient, StatusCode } from '../../src/http';
 import { StrapiConfigValidator } from '../../src/validators';
 

--- a/tests/unit/errors/client-errors.test.ts
+++ b/tests/unit/errors/client-errors.test.ts
@@ -1,4 +1,4 @@
-import { StrapiError, StrapiInitializationError, StrapiValidationError } from '../../../src';
+import { StrapiError, StrapiInitializationError, StrapiValidationError } from '../../../src/errors';
 
 describe('Strapi Errors', () => {
   describe('StrapiError', () => {

--- a/tests/unit/errors/http-errors.test.ts
+++ b/tests/unit/errors/http-errors.test.ts
@@ -6,7 +6,7 @@ import {
   HTTPInternalServerError,
   HTTPNotFoundError,
   HTTPTimeoutError,
-} from '../../../src';
+} from '../../../src/errors';
 import { StatusCode } from '../../../src/http';
 import { mockRequest, mockResponse } from '../mocks';
 

--- a/tests/unit/files/files-client-integration.test.ts
+++ b/tests/unit/files/files-client-integration.test.ts
@@ -1,10 +1,10 @@
-import { Strapi } from '../../../src/client';
+import { StrapiClient } from '../../../src/client';
 import { HTTPNotFoundError } from '../../../src/errors';
 import { FileNotFoundError } from '../../../src/files';
 import { mockFile, mockFiles } from '../../fixtures/files';
 
 describe('Strapi Client - Files Integration', () => {
-  let strapi: Strapi;
+  let strapi: StrapiClient;
   let mockFetch: jest.Mock;
 
   beforeEach(() => {
@@ -13,7 +13,7 @@ describe('Strapi Client - Files Integration', () => {
     jest.spyOn(globalThis, 'fetch').mockImplementation(mockFetch);
 
     // Create a new Strapi client instance
-    strapi = new Strapi({
+    strapi = new StrapiClient({
       baseURL: 'http://example.com/api',
     });
   });
@@ -80,7 +80,7 @@ describe('Strapi Client - Files Integration', () => {
       });
 
       // Create an authenticated Strapi client
-      const authenticatedStrapi = new Strapi({
+      const authenticatedStrapi = new StrapiClient({
         baseURL: 'http://example.com/api',
         auth: {
           strategy: 'api-token',
@@ -161,7 +161,7 @@ describe('Strapi Client - Files Integration', () => {
       });
 
       // Create an authenticated Strapi client
-      const authenticatedStrapi = new Strapi({
+      const authenticatedStrapi = new StrapiClient({
         baseURL: 'http://example.com/api',
         auth: {
           strategy: 'api-token',
@@ -247,7 +247,7 @@ describe('Strapi Client - Files Integration', () => {
       });
 
       // Create an authenticated Strapi client
-      const authenticatedStrapi = new Strapi({
+      const authenticatedStrapi = new StrapiClient({
         baseURL: 'http://example.com/api',
         auth: {
           strategy: 'api-token',

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -1,6 +1,6 @@
 import { strapi, StrapiInitializationError } from '../../src';
 import { ApiTokenAuthProvider } from '../../src/auth';
-import { Strapi } from '../../src/client';
+import { StrapiClient } from '../../src/client';
 
 import type { Config } from '../../src';
 
@@ -13,7 +13,7 @@ describe('strapi', () => {
     const client = strapi(config);
 
     // Assert
-    expect(client).toBeInstanceOf(Strapi);
+    expect(client).toBeInstanceOf(StrapiClient);
     expect(client).toHaveProperty('baseURL', config.baseURL);
   });
 
@@ -26,7 +26,7 @@ describe('strapi', () => {
     const client = strapi(config);
 
     // Assert
-    expect(client).toBeInstanceOf(Strapi);
+    expect(client).toBeInstanceOf(StrapiClient);
     expect(client).toHaveProperty('auth', {
       strategy: ApiTokenAuthProvider.identifier, // default auth strategy
       options: { token },

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -1,6 +1,7 @@
-import { strapi, StrapiInitializationError } from '../../src';
+import { strapi } from '../../src';
 import { ApiTokenAuthProvider } from '../../src/auth';
 import { StrapiClient } from '../../src/client';
+import { StrapiInitializationError } from '../../src/errors';
 
 import type { Config } from '../../src';
 

--- a/tests/unit/interceptors/auth.test.ts
+++ b/tests/unit/interceptors/auth.test.ts
@@ -1,4 +1,4 @@
-import { HTTPAuthorizationError } from '../../../src';
+import { HTTPAuthorizationError } from '../../../src/errors';
 import { AuthInterceptors } from '../../../src/interceptors';
 import { MockAuthManager, MockAuthProvider, MockHttpClient, MockURLValidator } from '../mocks';
 

--- a/tests/unit/validators/strapi-config.test.ts
+++ b/tests/unit/validators/strapi-config.test.ts
@@ -1,4 +1,4 @@
-import { StrapiValidationError, URLValidationError } from '../../../src';
+import { StrapiValidationError, URLValidationError } from '../../../src/errors';
 import { StrapiConfigValidator, URLValidator } from '../../../src/validators';
 
 import type { StrapiClientConfig } from '../../../src/client';

--- a/tests/unit/validators/strapi-config.test.ts
+++ b/tests/unit/validators/strapi-config.test.ts
@@ -1,7 +1,7 @@
 import { StrapiValidationError, URLValidationError } from '../../../src';
 import { StrapiConfigValidator, URLValidator } from '../../../src/validators';
 
-import type { StrapiConfig } from '../../../src/client';
+import type { StrapiClientConfig } from '../../../src/client';
 
 describe('Strapi Config Validator', () => {
   let urlValidatorMock: jest.Mocked<URLValidator>;
@@ -22,7 +22,7 @@ describe('Strapi Config Validator', () => {
         );
 
         // Act & Assert
-        expect(() => validator.validateConfig(config as StrapiConfig)).toThrow(expected);
+        expect(() => validator.validateConfig(config as StrapiClientConfig)).toThrow(expected);
       }
     );
 
@@ -40,7 +40,7 @@ describe('Strapi Config Validator', () => {
     it('should call validateBaseURL method with the baseURL', () => {
       // Arrange
       const validator = new StrapiConfigValidator(urlValidatorMock);
-      const config: StrapiConfig = { baseURL: 'http://valid.url' };
+      const config: StrapiClientConfig = { baseURL: 'http://valid.url' };
 
       // Act
       validator.validateConfig(config);


### PR DESCRIPTION
### What does it do?

- Renamed `Strapi` to `StrapiClient` to better understand its purpose
- Renamed `StrapiConfig` to `StrapiClientConfig` to follow the associated class' change
- Moved the client's `files` accessor from a getter to a property by making it public and renaming it from `_files` to `files`
- Added backward compatibility by keeping aliases of previously exported types, added todo to make sure they get removed in v2

### Why is it needed?

Cleanup, improve developer experience.

### How to test it?

Everything should work just like previous versions, new types should be available

