### PR TITLE
feat: :sparkles: add the option to pass custom headers

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -18,6 +18,9 @@ export interface StrapiClientConfig {
 
   /** Optional authentication configuration, which specifies a strategy and its details. */
   auth?: AuthConfig;
+
+  /** Optional custom headers to include with every request. */
+  headers?: Record<string, string>;
 }
 
 /**
@@ -107,8 +110,8 @@ export class StrapiClient {
     // It could be instantiated before but would throw an invalid URL error
     // instead of the client library itself throwing an initialization exception.
     this._httpClient = httpClientFactory
-      ? httpClientFactory({ baseURL: config.baseURL })
-      : new HttpClient({ baseURL: config.baseURL });
+      ? httpClientFactory({ baseURL: config.baseURL, headers: config.headers })
+      : new HttpClient({ baseURL: config.baseURL, headers: config.headers });
 
     this.files = new FilesManager(this._httpClient);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,8 +35,21 @@ export interface Config {
    *
    * - If excluded, the client operates without authentication.
    */
-
   auth?: string;
+
+  /**
+   * Custom headers to include with every request (optional).
+   *
+   * These headers will be added to all requests made by the client,
+   * but can be overridden by headers specific to individual requests.
+   *
+   * @example
+   * {
+   *   'X-Custom-Header': 'value',
+   *   'Accept-Language': 'en-US'
+   * }
+   */
+  headers?: Record<string, string>;
 }
 
 /**
@@ -76,9 +89,9 @@ export interface Config {
  *                                        or if the auth configuration is invalid.
  */
 export const strapi = (config: Config) => {
-  const { baseURL, auth } = config;
+  const { baseURL, auth, headers } = config;
 
-  const clientConfig: StrapiClientConfig = { baseURL };
+  const clientConfig: StrapiClientConfig = { baseURL, headers };
 
   // In this factory, while there is only one auth strategy available, users can't manually set the strategy options.
   // Since the client constructor needs to define a proper strategy,

--- a/src/validators/client.ts
+++ b/src/validators/client.ts
@@ -48,6 +48,7 @@ export class StrapiConfigValidator {
     }
 
     this.validateBaseURL(config.baseURL);
+    this.validateHeaders(config.headers);
 
     debug('validated client config successfully');
   }
@@ -71,5 +72,34 @@ export class StrapiConfigValidator {
 
       throw e;
     }
+  }
+
+  /**
+   * Validates the headers object to ensure it's a plain object with string key-value pairs.
+   *
+   * @param headers - The headers object to validate.
+   *
+   * @throws {StrapiValidationError} If the headers are invalid.
+   */
+  private validateHeaders(headers: unknown) {
+    debug('validating headers');
+
+    if (headers === undefined) {
+      return;
+    }
+
+    if (headers === null || typeof headers !== 'object' || Array.isArray(headers)) {
+      debug(`invalid headers type: %o (%s)`, headers, typeof headers);
+      throw new StrapiValidationError(new TypeError('Headers must be a valid object.'));
+    }
+
+    for (const [key, value] of Object.entries(headers)) {
+      if (typeof value !== 'string') {
+        debug(`invalid header value for key %s: %o (%s)`, key, value, typeof value);
+        throw new StrapiValidationError(new TypeError('Header values must be strings.'));
+      }
+    }
+
+    debug('headers validated successfully');
   }
 }

--- a/tests/unit/validators/strapi-config.test.ts
+++ b/tests/unit/validators/strapi-config.test.ts
@@ -62,4 +62,129 @@ describe('Strapi Config Validator', () => {
       expect(() => validator.validateConfig({ baseURL })).toThrow(StrapiValidationError);
     });
   });
+
+  describe('validateHeaders', () => {
+    it('should accept custom headers in the config', () => {
+      // Arrange
+      const validator = new StrapiConfigValidator(urlValidatorMock);
+      const config: StrapiClientConfig = {
+        baseURL: 'https://example.com',
+        headers: {
+          Authorization: 'Bearer token123',
+          'Custom-Header': 'Custom Value',
+        },
+      };
+
+      // Act & Assert
+      expect(() => validator.validateConfig(config)).not.toThrow();
+    });
+
+    it('should throw StrapiValidationError if headers is not an object', () => {
+      // Arrange
+      const validator = new StrapiConfigValidator(urlValidatorMock);
+      const baseURL = 'https://example.com';
+      const expected = new StrapiValidationError(new TypeError('Headers must be a valid object.'));
+
+      // Act & Assert
+      expect(() =>
+        validator.validateConfig({
+          baseURL,
+          // @ts-expect-error: Testing invalid headers
+          headers: 'invalid headers',
+        })
+      ).toThrow(expected);
+    });
+
+    it('should validate header values are strings not number', () => {
+      // Arrange
+      const validator = new StrapiConfigValidator(urlValidatorMock);
+      const baseURL = 'https://example.com';
+      const headers = {
+        'Another-Header': 123,
+      };
+
+      const expected = new StrapiValidationError(new TypeError('Header values must be strings.'));
+
+      // Act & Assert
+      expect(() =>
+        validator.validateConfig({
+          baseURL,
+          // @ts-expect-error - Testing invalid header values
+          headers,
+        })
+      ).toThrow(expected);
+    });
+
+    it('should validate header values are strings not null', () => {
+      // Arrange
+      const validator = new StrapiConfigValidator(urlValidatorMock);
+      const baseURL = 'https://example.com';
+      const headers = {
+        'Another-Header': null,
+      };
+
+      const expected = new StrapiValidationError(new TypeError('Header values must be strings.'));
+
+      // Act & Assert
+      expect(() =>
+        validator.validateConfig({
+          baseURL,
+          // @ts-expect-error - Testing invalid header values
+          headers,
+        })
+      ).toThrow(expected);
+    });
+
+    it('should validate header values are strings not boolean', () => {
+      // Arrange
+      const validator = new StrapiConfigValidator(urlValidatorMock);
+      const baseURL = 'https://example.com';
+      const headers = {
+        'Custom-Header': true,
+      };
+
+      const expected = new StrapiValidationError(new TypeError('Header values must be strings.'));
+
+      // Act & Assert
+      expect(() =>
+        validator.validateConfig({
+          baseURL,
+          // @ts-expect-error - Testing invalid header values
+          headers,
+        })
+      ).toThrow(expected);
+    });
+
+    it('should validate header values are strings not undefined', () => {
+      // Arrange
+      const validator = new StrapiConfigValidator(urlValidatorMock);
+      const baseURL = 'https://example.com';
+      const headers = {
+        'Custom-Header': undefined,
+      };
+
+      const expected = new StrapiValidationError(new TypeError('Header values must be strings.'));
+
+      // Act & Assert
+      expect(() =>
+        validator.validateConfig({
+          baseURL,
+          // @ts-expect-error - Testing invalid header values
+          headers,
+        })
+      ).toThrow(expected);
+    });
+
+    it('should handle empty headers object', () => {
+      // Arrange
+      const validator = new StrapiConfigValidator(urlValidatorMock);
+      const config: StrapiClientConfig = {
+        baseURL: 'https://example.com',
+        headers: {},
+      };
+
+      // Act & Assert
+      expect(() => validator.validateConfig(config)).not.toThrow();
+    });
+  });
 });


### PR DESCRIPTION
### What does it do?

Now we can add some custom headers for all request to strapi client.

### Why is it needed?

Can be useful when needed to ask for only draft or preview mode

### How to test it?

I added unit test related to it, and config for headers was already here just not consume

### Related issue(s)/PR(s)

Issue : [#77](https://github.com/strapi/client/issues/77)