### PR TITLE
docs(readme): add section for configuring custom headers in Strapi client

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,11 +134,7 @@ const client = strapi({
 });
 ```
 
-**Header Precedence:**
-
 - Custom headers specified in the client configuration are applied to all requests
-- Authentication headers (e.g., `Authorization` from API tokens) take precedence over custom headers
-- Headers specified in individual requests (e.g., in `fetch()` calls) take precedence over both custom and authentication headers
 
 **Example: Using Custom Headers**
 
@@ -154,13 +150,6 @@ const client = strapi({
 
 // Headers will be included in all requests
 const articles = await client.collection('articles').find();
-
-// Override headers for a specific request
-const article = await client.fetch('/articles/1', {
-  headers: {
-    'Accept-Language': 'fr-FR', // This will override the client-level header
-  },
-});
 ```
 
 ## 📚 API Reference

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ const client = strapi({
 });
 ```
 
-- Custom headers specified in the client configuration are applied to all requests
+Custom headers specified in the client configuration are applied to all requests
 
 **Example: Using Custom Headers**
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
    - [Basic Configuration](#basic-configuration)
    - [Authentication](#authentication)
      - [API Token Authentication](#api-token-authentication)
+     - [Custom Headers](#custom-headers)
 3. [API Reference](#-api-reference)
 4. [Resource Managers](#-resource-managers)
    - [`.collection()`](#collectionresource)
@@ -115,6 +116,50 @@ const client = strapi({
   baseURL: 'http://localhost:1337/api',
   // Auth configuration
   auth: 'your-api-token-here',
+});
+```
+
+#### Custom Headers
+
+You can configure custom headers to be included with every request made by the client:
+
+```typescript
+const client = strapi({
+  baseURL: 'http://localhost:1337/api',
+  auth: 'your-api-token-here',
+  headers: {
+    'X-Custom-Header': 'value',
+    'Accept-Language': 'en-US',
+  },
+});
+```
+
+**Header Precedence:**
+
+- Custom headers specified in the client configuration are applied to all requests
+- Authentication headers (e.g., `Authorization` from API tokens) take precedence over custom headers
+- Headers specified in individual requests (e.g., in `fetch()` calls) take precedence over both custom and authentication headers
+
+**Example: Using Custom Headers**
+
+```typescript
+// Initialize client with custom headers
+const client = strapi({
+  baseURL: 'http://localhost:1337/api',
+  headers: {
+    'X-Request-ID': '12345',
+    'Accept-Language': 'en-US',
+  },
+});
+
+// Headers will be included in all requests
+const articles = await client.collection('articles').find();
+
+// Override headers for a specific request
+const article = await client.fetch('/articles/1', {
+  headers: {
+    'Accept-Language': 'fr-FR', // This will override the client-level header
+  },
 });
 ```
 


### PR DESCRIPTION
### What does it do?
Covers the changes made in https://github.com/strapi/client/pull/76 in the repo README

