### PR TITLE
Plugin specific support (users-permissions)

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -309,7 +309,7 @@ export class StrapiClient {
    *
    * @param resource - The plural name of the collection to interact with.
    *                     This should match the collection name as defined in the Strapi app.
-   * @param [options] - Optional parameter to specify additional configuration such as custom API path.
+   * @param [options] - Optional parameter to specify additional configuration such as custom API path or plugin context.
    *
    * @returns An instance of {@link CollectionTypeManager} for the given {@link resource}.
    *
@@ -340,15 +340,34 @@ export class StrapiClient {
    * // Example with a custom API path
    * const customArticles = client.collection('articles', { path: '/custom-articles-path' });
    * const customAllArticles = await customArticles.find();
+   *
+   * // Example: Working with users-permissions plugin (no data wrapping, no route prefix)
+   * const users = client.collection('users', {
+   *   plugin: {
+   *     name: 'users-permissions',
+   *     prefix: '' // some users-permissions routes are not prefixed
+   *   }
+   * });
+   *
+   *
+   * // Example: Working with a custom plugin (routes prefixed by default)
+   * const posts = client.collection('posts', {
+   *   plugin: {
+   *     name: 'blog', // routes are prefixed with the plugin name by default
+   *   }
+   * });
+   *
+   * // This makes requests to /blog/posts
+   * const newPost = await posts.create({ title: 'My Post', content: 'Post content' });
    * ```
    *
    * @see CollectionTypeManager
    * @see StrapiClient
    */
   collection(resource: string, options: ClientCollectionOptions = {}) {
-    const { path } = options;
+    const { path, plugin } = options;
 
-    return new CollectionTypeManager({ resource, path }, this._httpClient);
+    return new CollectionTypeManager({ resource, path, plugin }, this._httpClient);
   }
 
   /**
@@ -395,5 +414,5 @@ export class StrapiClient {
 }
 
 // Local Client Types
-export type ClientCollectionOptions = Pick<ContentTypeManagerOptions, 'path'>;
+export type ClientCollectionOptions = Pick<ContentTypeManagerOptions, 'path' | 'plugin'>;
 export type SingleCollectionOptions = Pick<ContentTypeManagerOptions, 'path'>;

--- a/src/content-types/abstract.ts
+++ b/src/content-types/abstract.ts
@@ -15,6 +15,26 @@ export interface ContentTypeManagerOptions {
    * If not provided, the resource name is used to construct the path.
    */
   path?: string;
+
+  /**
+   * Optional plugin configuration parameters.
+   *
+   * If not provided, the resource is assumed to be a regular content-type.
+   */
+  plugin?: {
+    /**
+     * When specified, indicates that this content-type belongs to a specific plugin.
+     */
+    name: string;
+    /**
+     * Optional prefix for plugin routes.
+     *
+     * When a plugin is specified, routes are prefixed with the plugin name by default.
+     * Setting this to an empty string ('') will disable prefixing for plugins
+     * that don't use it. e.g. the 'users-permissions' plugin.
+     */
+    prefix?: string;
+  };
 }
 
 /**
@@ -53,13 +73,53 @@ export abstract class AbstractContentTypeManager {
   }
 
   /**
+   * Gets the configured plugin name for this manager.
+   *
+   * Returns `undefined` if no plugin is explicitly set in the options.
+   */
+  protected get _pluginName() {
+    return this._options.plugin?.name;
+  }
+
+  /**
+   * Gets the configured prefix for this manager.
+   *
+   * Returns the explicit prefix if set, otherwise defaults to the plugin name if a plugin is specified.
+   */
+  protected get _pluginPrefix() {
+    // If prefix is explicitly set (including ''), use it
+    if (this._options.plugin?.prefix !== undefined) {
+      return this._options.plugin.prefix;
+    }
+
+    // If plugin is specified but no explicit prefix, default to plugin name
+    if (this._pluginName) {
+      return this._pluginName;
+    }
+
+    // No plugin, no prefix
+    return undefined;
+  }
+
+  /**
    * Gets the root path for the resource.
    *
    * If a custom path is configured, it returns that value.
    *
-   * Otherwise, it defaults to `/<resource>`.
+   * If a plugin is specified, the path is constructed with the plugin prefix.
+   * - With plugin prefix: `/<prefix>/<resource>`
+   * - Without plugin: `/<resource>`
    */
   protected get _rootPath() {
-    return this._path ?? `/${this._resource}`;
+    if (this._path) {
+      return this._path;
+    }
+
+    const prefix = this._pluginPrefix;
+    if (prefix) {
+      return `/${prefix}/${this._resource}`;
+    }
+
+    return `/${this._resource}`;
   }
 }


### PR DESCRIPTION
### What does it do?

Adds plugin-specific handling to the Strapi client library. The changes include:

- Added optional `plugin` configuration parameter to `ContentTypeManagerOptions` with configurable name and prefix
- Implemented conditional data wrapping logic that skips wrapping payloads for the users-permissions plugin
- Enhanced route construction to support plugin-specific prefixes (e.g., `/plugin-name/resource` or `/resource` for plugins without prefixes)
- Updated the client's `collection()` method to accept plugin configuration options

### Why is it needed?

The users-permissions plugin in Strapi has a different API contract than regular content-types. It expects raw payload data without the standard `{ data: {...} }` wrapper that other content-types require. Without this change, attempting to create users via the client fails with validation errors because the API receives the data in an unexpected format.

### How to test it?

1. Set up a Strapi application with users-permissions plugin enabled
2. Use the client to create a user with plugin configuration:
   ```javascript
   const users = client.collection('users', { 
     plugin: { name: 'users-permissions', prefix: '' } 
   });

   await users.create({
     username: 'testuser',
     email: 'test@example.com',
     password: 'password123',
     role: 1
   });
   ```
3. Verify the request succeeds and the user is created
4. Run the test suite to verify all plugin-specific behaviors work correctly

### Related issue(s)/PR(s)
