### PR TITLE
ci: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directories:
+      - /
+      - /demo/node-javascript
+      - /demo/node-typescript
+      - /demo/next-server-components
+      - /demo/react-vite
+      - /demo/.strapi-app
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: chore
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci


### PR DESCRIPTION
### What does it do?

Adds a Dependabot v2 config () that runs weekly for the `npm` ecosystem (pnpm lockfiles at the repo root and under each demo app) and for `github-actions`, with a cap of 10 open npm PRs and `chore` / `ci` commit prefixes to match conventional commitlint.

### Why is it needed?

Keeps dependencies and workflow action pins updated on a predictable schedule without manual tracking.

### How to test it?

After merge, confirm Dependabot is enabled for the repo and appears under **Insights → Dependency graph → Dependabot** (or wait for the weekly run). No runtime code paths are affected.

### Related issue(s)/PR(s)

None.
