### PR TITLE
chore: ignore @strapi/* in demo app Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,12 +7,22 @@ updates:
       - /demo/node-typescript
       - /demo/next-server-components
       - /demo/react-vite
-      - /demo/.strapi-app
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
     commit-message:
       prefix: chore
+
+  # Demo Strapi app: @strapi/* versions are upgraded by demo-strapi-version-check.yml
+  - package-ecosystem: npm
+    directory: /demo/.strapi-app
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: chore
+    ignore:
+      - dependency-name: '@strapi/*'
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Summary

- Split `demo/.strapi-app` into its own Dependabot npm entry
- Ignore `@strapi/*` there so Strapi patch bumps stay owned by `demo-strapi-version-check.yml` (one PR, all three packages in sync)
- Other `demo/.strapi-app` deps (e.g. `better-sqlite3`, `styled-components`, `@types/node`) still get Dependabot PRs

## Why

Dependabot was opening per-package Strapi PRs (#153, #155) while the scheduled workflow also opened a combined upgrade (#146), causing duplicate/conflicting work.

## Test plan

- [ ] Dependabot config validates on merge (GitHub shows no dependabot.yml errors)
- [ ] After next weekly run, no new Dependabot PRs for `@strapi/*` under `demo/.strapi-app`
- [ ] Non-Strapi bumps in `demo/.strapi-app` still open as before